### PR TITLE
update firefox regexp

### DIFF
--- a/lib/firefox.js
+++ b/lib/firefox.js
@@ -1,7 +1,7 @@
 var request = require('request');
 var os = require('os');
-var reFilename = /^.*((?:Firefox |firefox-)[0-9\.ba]+\..*[exe|dmg|tar.bz2]).*/;
-var reVersion = /^.*(?:Firefox |firefox-)([0-9\.ba]+)\..*[exe|dmg|tar.bz2]$/;
+var reFilename = /^.*((?:Firefox |firefox-)(.*)[0-9\.ba]+\..*[exe|dmg|tar.bz2]).*/;
+var reVersion = /^.*(?:Firefox |firefox-)(.*)([0-9\.ba]+)\..*[exe|dmg|tar.bz2]$/;
 
 var PLATFORM_MAPPINGS = {
 	darwin: 'osx',


### PR DESCRIPTION
which is required as of November 18th 2022 as seen in
  https://github.com/webrtc/samples/actions?query=event%3Aschedule

Fixes https://github.com/DamonOehlman/travis-multirunner/issues/56