### PR TITLE
replace omahaproxy with versionhistory.googleapis.com

### DIFF
--- a/lib/chrome.js
+++ b/lib/chrome.js
@@ -30,12 +30,12 @@ var CHANNEL_LINKS = {
 var detectedPlatform = PLATFORM_MAPPINGS[os.platform()];
 
 function getVersionInformation(channel, platform, callback) {
-  request('http://omahaproxy.appspot.com/all/json', { json: true }, function(err, response, body) {
+  request('https://versionhistory.googleapis.com/v1/chrome/platforms/' + platform + '/channels/' + channel + '/versions/',
+        { json: true }, function(err, response, body) {
     if (err) return callback(err);
-    var applicable = body.filter(function(r) { return r.os === platform; });
-    if (!applicable || applicable.length === 0) return callback();
+    var result = body.versions;
+    if (!result || result.length === 0) return callback();
 
-    var result = applicable[0].versions.filter(function(v) { return v.channel === channel; });
     return callback(null, (result.length > 0 ? result[0] : null));
   })
 }

--- a/test/chrome_test.js
+++ b/test/chrome_test.js
@@ -29,6 +29,7 @@ describe('Chrome sleuthing', function() {
 
 	it('should use the correct URL for canary on mac', function(done) {
 		sleuth.discover('chrome', {
+            platform: 'mac',
 			channel: 'nightly'
 		}, function(err, info) {
 			if (err || !info) return done(err || 'No result found');


### PR DESCRIPTION
since omahaproxy will be turned off on March 31st 2023:
  https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE/m/PhUj_inyAQAJ